### PR TITLE
Add fixes for bugs in second session

### DIFF
--- a/setup1.sh
+++ b/setup1.sh
@@ -1,6 +1,6 @@
 # enable needed cgroups
 # mangle command line. Should probably match the defaults. Definitely doesn't match if you're not using raspbian lite
-echo 'console=serial0,115200 console=tty1 root=PARTUUID=27dd93d1-02 rootfstype=ext4 fsck.repair=yes rootwait cgroup_enable=cpuset cgroup_enable=memory cgroup_memory=1' |sudo tee /boot/cmdline.txt
+echo "console=serial0,115200 console=tty1 root=PARTUUID=$(ls /dev/disk/by-partuuid|sort|tail -n 1) rootfstype=ext4 fsck.repair=yes rootwait cgroup_enable=cpuset cgroup_enable=memory cgroup_memory=1"|sudo tee /boot/cmdline.txt
 # just append. The params must be on one line, so the previous line might be more reliable
 #echo ' cgroup_enable=cpuset cgroup_enable=memory cgroup_memory=1' |sudo tee -a /boot/cmdline.txt
 

--- a/setup1.sh
+++ b/setup1.sh
@@ -1,9 +1,12 @@
 # enable needed cgroups
-echo ' cgroup_enable=cpuset cgroup_enable=memory cgroup_memory=1' |sudo tee -a /boot/cmdline.txt
+# mangle command line. Should probably match the defaults. Definitely doesn't match if you're not using raspbian lite
+echo 'console=serial0,115200 console=tty1 root=PARTUUID=27dd93d1-02 rootfstype=ext4 fsck.repair=yes rootwait cgroup_enable=cpuset cgroup_enable=memory cgroup_memory=1' |sudo tee /boot/cmdline.txt
+# just append. The params must be on one line, so the previous line might be more reliable
+#echo ' cgroup_enable=cpuset cgroup_enable=memory cgroup_memory=1' |sudo tee -a /boot/cmdline.txt
 
 #preconfigure docker
 sudo mkdir /etc/docker
-cat '
+echo '
 {
   "exec-opts": ["native.cgroupdriver=systemd"],
   "log-driver": "json-file",


### PR DESCRIPTION
- some people had the boot cmd line on two lines. 
- Also apparently cat for the docker config resulted in an empty docker.json